### PR TITLE
Implement select() builtin function (#5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ dependency-reduced-pom.xml
 *.war
 *.ear
 hs_err_pid*
+
+# Claude Code agents and commands (user-specific)
+.claude/
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ A Java 8+ port of [jq](https://jqlang.github.io/jq/), the lightweight command-li
 - Comparison operators: `==`, `!=`, `<`, `<=`, `>`, `>=`
 - Arithmetic operators: `+`, `-`, `*`, `/`, `%` (also string/array concatenation with `+`)
 - Logical operators: `and`, `or`, `not`
-- Built-in functions: `length`, `keys`, `type`, `map(expr)`, `builtins`
+- Built-in functions: `length`, `keys`, `type`, `map(expr)`, `select(expr)`, `builtins`
 
 ## Usage
 

--- a/jq4java-core/src/main/java/com/dortegau/jq4java/ast/BuiltinRegistry.java
+++ b/jq4java-core/src/main/java/com/dortegau/jq4java/ast/BuiltinRegistry.java
@@ -13,6 +13,7 @@ public class BuiltinRegistry {
       Class.forName("com.dortegau.jq4java.ast.Keys");
       Class.forName("com.dortegau.jq4java.ast.Type");
       Class.forName("com.dortegau.jq4java.ast.MapFunction");
+      Class.forName("com.dortegau.jq4java.ast.Select");
     } catch (ClassNotFoundException e) {
       // Ignore
     }

--- a/jq4java-core/src/main/java/com/dortegau/jq4java/ast/Select.java
+++ b/jq4java-core/src/main/java/com/dortegau/jq4java/ast/Select.java
@@ -1,0 +1,29 @@
+package com.dortegau.jq4java.ast;
+
+import com.dortegau.jq4java.json.JqValue;
+
+import java.util.stream.Stream;
+
+public class Select implements Expression {
+    private final Expression condition;
+
+    static {
+        BuiltinRegistry.register("select", 1);
+    }
+
+    public Select(Expression condition) {
+        this.condition = condition;
+    }
+
+    @Override
+    public Stream<JqValue> evaluate(JqValue input) {
+        return condition.evaluate(input)
+                .flatMap(conditionResult -> {
+                    if (conditionResult.isTruthy()) {
+                        return Stream.of(input);
+                    } else {
+                        return Stream.empty();
+                    }
+                });
+    }
+}

--- a/jq4java-core/src/main/java/com/dortegau/jq4java/parser/JqAstBuilder.java
+++ b/jq4java-core/src/main/java/com/dortegau/jq4java/parser/JqAstBuilder.java
@@ -21,6 +21,7 @@ import com.dortegau.jq4java.ast.Not;
 import com.dortegau.jq4java.ast.ObjectConstruction;
 import com.dortegau.jq4java.ast.Or;
 import com.dortegau.jq4java.ast.Pipe;
+import com.dortegau.jq4java.ast.Select;
 import com.dortegau.jq4java.ast.Type;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -314,6 +315,8 @@ public class JqAstBuilder extends JqGrammarBaseVisitor<Expression> {
     switch (functionName) {
       case "map":
         return new MapFunction(arg);
+      case "select":
+        return new Select(arg);
       default:
         throw new RuntimeException("Unknown function: " + functionName);
     }

--- a/jq4java-core/src/test/java/com/dortegau/jq4java/JqErrorTest.java
+++ b/jq4java-core/src/test/java/com/dortegau/jq4java/JqErrorTest.java
@@ -208,4 +208,18 @@ class JqErrorTest {
         () -> Jq.execute("{a, b: .x}", "[1,2,3]"));
     assertTrue(ex.getMessage().contains("Cannot index array with string"));
   }
+
+  @Test
+  void testSelectWithoutArguments() {
+    RuntimeException ex = assertThrows(RuntimeException.class,
+        () -> Jq.execute("select", "null"));
+    assertTrue(ex.getMessage().contains("Parse error"));
+  }
+
+  @Test
+  void testSelectWithInvalidExpression() {
+    RuntimeException ex = assertThrows(RuntimeException.class,
+        () -> Jq.execute("select(.nonexistent > 10)", "42"));
+    assertTrue(ex.getMessage().contains("Cannot index number with string"));
+  }
 }

--- a/jq4java-core/src/test/java/com/dortegau/jq4java/JqTest.java
+++ b/jq4java-core/src/test/java/com/dortegau/jq4java/JqTest.java
@@ -232,7 +232,16 @@ class JqTest {
         "'{a,b} // {\"default\":true}' ; '{\"a\":1,\"b\":2}' ; '{\"a\":1,\"b\":2}'",
         "'{x} // {\"default\":true}' ; '{\"y\":1}' ; '{\"x\":null}'",
         "'map({a})' ; '[{\"a\":1,\"b\":2},{\"a\":3,\"b\":4}]' ; '[{\"a\":1},{\"a\":3}]'",
-        "'{a,b}.a + {c,d}.c' ; '{\"a\":5,\"b\":10,\"c\":3,\"d\":7}' ; '8'"
+        "'{a,b}.a + {c,d}.c' ; '{\"a\":5,\"b\":10,\"c\":3,\"d\":7}' ; '8'",
+        "'map(select(. > 2))' ; '[1,2,3,4,5]' ; '[3,4,5]'",
+        "'map(select(.age >= 18))' ; '[{\"name\":\"Alice\",\"age\":25},{\"name\":\"Bob\",\"age\":15},{\"name\":\"Charlie\",\"age\":30}]' ; '[{\"name\":\"Alice\",\"age\":25},{\"name\":\"Charlie\",\"age\":30}]'",
+        "'map(select(length > 2))' ; '[\"a\",\"bb\",\"ccc\",\"dddd\"]' ; '[\"ccc\",\"dddd\"]'",
+        "'map(select(type == \"number\"))' ; '[1,\"a\",2,true,3]' ; '[1,2,3]'",
+        "'.users | map(select(.active))' ; '{\"users\":[{\"name\":\"Alice\",\"active\":true},{\"name\":\"Bob\",\"active\":false},{\"name\":\"Charlie\",\"active\":true}]}' ; '[{\"name\":\"Alice\",\"active\":true},{\"name\":\"Charlie\",\"active\":true}]'",
+        "'map(select(. > 0) | . * 2)' ; '[-1,2,-3,4]' ; '[4,8]'",
+        "'.items | map(select(.price < 100)) | length' ; '{\"items\":[{\"price\":50},{\"price\":150},{\"price\":30}]}' ; '2'",
+        "'[.[] | select(. % 2 == 0)]' ; '[1,2,3,4,5,6]' ; '[2,4,6]'",
+        "'map(select(.status == \"active\") | .name)' ; '[{\"name\":\"Alice\",\"status\":\"active\"},{\"name\":\"Bob\",\"status\":\"inactive\"},{\"name\":\"Charlie\",\"status\":\"active\"}]' ; '[\"Alice\",\"Charlie\"]'"
     }, delimiter = ';')
     void testCombinedOperations(String program, String input, String expected) {
         assertEquals(expected, Jq.execute(program, input));
@@ -344,6 +353,30 @@ class JqTest {
         "'null | not', null, true"
     })
     void testLogicalOperators(String program, String input, String expected) {
+        assertEquals(expected, Jq.execute(program, input));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "'map(select(. > 3))' ; '[1,2,3,4,5]' ; '[4,5]'",
+        "'map(select(. > 10))' ; '[1,2,3,4,5]' ; '[]'",
+        "'map(select(.a > 1))' ; '[{\"a\":1},{\"a\":2},{\"a\":3}]' ; '[{\"a\":2},{\"a\":3}]'",
+        "'select(. == \"hello\")' ; '\"hello\"' ; '\"hello\"'",
+        "'select(. == \"world\")' ; '\"hello\"' ; ''",
+        "'select(.)' ; 'true' ; 'true'",
+        "'select(.)' ; 'false' ; ''",
+        "'select(.)' ; 'null' ; ''",
+        "'select(.)' ; '0' ; '0'",
+        "'select(.)' ; '\"\"' ; '\"\"'",
+        "'select(.)' ; '[]' ; '[]'",
+        "'select(.)' ; '{}' ; '{}'",
+        "'select(.name == \"Alice\")' ; '{\"name\":\"Alice\",\"age\":25}' ; '{\"name\":\"Alice\",\"age\":25}'",
+        "'select(.name == \"Bob\")' ; '{\"name\":\"Alice\",\"age\":25}' ; ''",
+        "'select(length > 2)' ; '\"hello\"' ; '\"hello\"'",
+        "'select(length > 10)' ; '\"hello\"' ; ''",
+        "'map(select(type == \"string\"))' ; '[1,\"a\",true,\"b\"]' ; '[\"a\",\"b\"]'"
+    }, delimiter = ';')
+    void testSelect(String program, String input, String expected) {
         assertEquals(expected, Jq.execute(program, input));
     }
 


### PR DESCRIPTION
## Summary
Implements the `select()` builtin function for filtering values based on conditions.

## Changes
- Add `Select` class implementing filtering based on truthiness
- Register `select/1` in `BuiltinRegistry`
- Update `JqAstBuilder` to handle `select()` function calls
- Add comprehensive tests for `select()` functionality
- Add error tests for invalid `select()` usage
- Update README.md to include `select()` in implemented features
- Add `.claude/` and `CLAUDE.md` to `.gitignore`

## Test Plan
- [x] All existing tests pass
- [x] New tests added for happy path scenarios
- [x] Error tests added for edge cases  
- [x] Combined tests with other features (map, length, type)
- [x] Validated against native jq CLI behavior

## Examples
```bash
# Basic filtering
echo '[1,2,3,4,5]' | jq 'map(select(. > 3))'
# Output: [4,5]

# Truthiness filtering  
echo '[true, false, null, 0, "", "hello"]' | jq '.[] | select(.)'
# Output: true, 0, "", "hello"

# Object filtering
echo '[{"name":"Alice","age":25},{"name":"Bob","age":15}]' | jq 'map(select(.age >= 18))'
# Output: [{"name":"Alice","age":25}]
```

Closes #5