### PR TITLE
Implement abs builtin with validation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A Java 8+ port of [jq](https://jqlang.github.io/jq/), the lightweight command-li
 - Arithmetic operators: `+`, `-`, `*`, `/`, `%` (also string/array concatenation with `+`)
 - Logical operators: `and`, `or`, `not`
 - Conditional expressions: `if-then-else-end`, `if-then-elif-then-else-end`, `if-then-end` (optional else)
-- Built-in functions: `length`, `keys`, `type`, `map(expr)`, `select(expr)`, `builtins`, `flatten`, `add`, `sort`, `reverse`, `unique`, `transpose`, `range(n)`, `range(from; to)`, `range(from; to; step)`, `to_entries`, `from_entries`
+- Built-in functions: `length`, `keys`, `type`, `map(expr)`, `select(expr)`, `builtins`, `flatten`, `add`, `abs`, `sort`, `reverse`, `unique`, `transpose`, `range(n)`, `range(from; to)`, `range(from; to; step)`, `to_entries`, `from_entries`
 
 ## Usage
 

--- a/jq4java-core/src/main/java/com/dortegau/jq4java/ast/Abs.java
+++ b/jq4java-core/src/main/java/com/dortegau/jq4java/ast/Abs.java
@@ -1,0 +1,15 @@
+package com.dortegau.jq4java.ast;
+
+import com.dortegau.jq4java.json.JqValue;
+import java.util.stream.Stream;
+
+public class Abs implements Expression {
+  static {
+    BuiltinRegistry.register("abs", 0);
+  }
+
+  @Override
+  public Stream<JqValue> evaluate(JqValue input) {
+    return Stream.of(input.abs());
+  }
+}

--- a/jq4java-core/src/main/java/com/dortegau/jq4java/ast/BuiltinRegistry.java
+++ b/jq4java-core/src/main/java/com/dortegau/jq4java/ast/BuiltinRegistry.java
@@ -16,6 +16,7 @@ public class BuiltinRegistry {
       Class.forName("com.dortegau.jq4java.ast.Select");
       Class.forName("com.dortegau.jq4java.ast.Flatten");
       Class.forName("com.dortegau.jq4java.ast.Add");
+      Class.forName("com.dortegau.jq4java.ast.Abs");
       Class.forName("com.dortegau.jq4java.ast.Sort");
       Class.forName("com.dortegau.jq4java.ast.Reverse");
       Class.forName("com.dortegau.jq4java.ast.Unique");

--- a/jq4java-core/src/main/java/com/dortegau/jq4java/ast/ZeroArgFunction.java
+++ b/jq4java-core/src/main/java/com/dortegau/jq4java/ast/ZeroArgFunction.java
@@ -20,6 +20,8 @@ public class ZeroArgFunction implements Expression {
         return new Flatten().evaluate(input);
       case "add":
         return new Add().evaluate(input);
+      case "abs":
+        return new Abs().evaluate(input);
       case "sort":
         return new Sort().evaluate(input);
       case "reverse":

--- a/jq4java-core/src/main/java/com/dortegau/jq4java/json/JqValue.java
+++ b/jq4java-core/src/main/java/com/dortegau/jq4java/json/JqValue.java
@@ -87,4 +87,6 @@ public interface JqValue extends Comparable<JqValue> {
   JqValue unique();
 
   JqValue transpose();
+
+  JqValue abs();
 }

--- a/jq4java-core/src/main/java/com/dortegau/jq4java/json/OrgJsonValue.java
+++ b/jq4java-core/src/main/java/com/dortegau/jq4java/json/OrgJsonValue.java
@@ -766,4 +766,24 @@ public class OrgJsonValue implements JqValue {
 
     return new OrgJsonValue(result);
   }
+
+  @Override
+  public JqValue abs() {
+    if (value instanceof Number) {
+      double result = Math.abs(((Number) value).doubleValue());
+      if (result == (long) result) {
+        return new OrgJsonValue((long) result);
+      }
+      return new OrgJsonValue(result);
+    }
+
+    String type =
+        value == JSONObject.NULL ? "null"
+            : value instanceof String ? "string"
+            : value instanceof Boolean ? "boolean"
+            : value instanceof JSONArray ? "array"
+            : value instanceof JSONObject ? "object"
+            : "unknown";
+    throw new RuntimeException(type + " (" + this + ") cannot be used with abs");
+  }
 }

--- a/jq4java-core/src/test/java/com/dortegau/jq4java/JqErrorTest.java
+++ b/jq4java-core/src/test/java/com/dortegau/jq4java/JqErrorTest.java
@@ -140,6 +140,20 @@ class JqErrorTest {
   }
 
   @Test
+  void testAbsOnString() {
+    RuntimeException ex = assertThrows(RuntimeException.class,
+        () -> Jq.execute("abs", "\"hello\""));
+    assertTrue(ex.getMessage().contains("cannot be used with abs"));
+  }
+
+  @Test
+  void testAbsOnArray() {
+    RuntimeException ex = assertThrows(RuntimeException.class,
+        () -> Jq.execute("abs", "[1,2,3]"));
+    assertTrue(ex.getMessage().contains("cannot be used with abs"));
+  }
+
+  @Test
   void testSubtractStrings() {
     RuntimeException ex = assertThrows(RuntimeException.class,
         () -> Jq.execute("\"hello\" - \"world\"", "null"));

--- a/jq4java-core/src/test/java/com/dortegau/jq4java/JqTest.java
+++ b/jq4java-core/src/test/java/com/dortegau/jq4java/JqTest.java
@@ -690,10 +690,23 @@ class JqTest {
         "'-(-.)' ; '5' ; '5'",
         "'-(-(.))' ; '-3' ; '-3'",
 
-        // The test case from jq.test:39 (with length instead of abs since abs not implemented)
-        "'{x:-1},{x:-.},{x:-.|length}' ; '1' ; '{\"x\":-1}\n{\"x\":-1}\n{\"x\":1}'"
+        // The test case from jq.test:39 involving abs
+        "'{x:-1},{x:-.},{x:-.|abs}' ; '1' ; '{\"x\":-1}\n{\"x\":-1}\n{\"x\":1}'"
     }, delimiter = ';')
     void testUnaryMinusOperator(String program, String input, String expected) {
+        assertEquals(expected, Jq.execute(program, input));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "'abs' ; '-5' ; '5'",
+        "'abs' ; '5' ; '5'",
+        "'abs' ; '0' ; '0'",
+        "'abs' ; '-3.5' ; '3.5'",
+        "'[.[] | abs]' ; '[-1,0,2]' ; '[1,0,2]'",
+        "'map(abs)' ; '[-1,2,-3]' ; '[1,2,3]'"
+    }, delimiter = ';')
+    void testAbsFunction(String program, String input, String expected) {
         assertEquals(expected, Jq.execute(program, input));
     }
 }


### PR DESCRIPTION
## Summary
- add an `abs` builtin expression and register it alongside the other zero-argument filters
- extend the JSON value abstraction to compute numeric absolute values and emit descriptive errors for unsupported types
- document the new builtin and cover happy path, edge, and failure scenarios in the automated tests

## Testing
- `./mvnw test` *(fails: Maven wrapper cannot be downloaded in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68f426c787588333bf5eaca6d936fc24