### PR TITLE
Allow mvnw to use installed Maven when offline

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -160,10 +160,14 @@ fi
 # already available on the PATH we fall back to it so that ./mvnw continues to
 # work without requiring network connectivity.  This mirrors what developers
 # would typically do manually when offline.
-if [ "${MVN_CMD#mvn}" != "$MVN_CMD" ] && command -v mvn >/dev/null 2>&1; then
-  verbose "using existing mvn on PATH"
-  exec "$(command -v mvn)" "$@"
-fi
+case "$MVN_CMD" in
+  mvn*)
+    if command -v mvn >/dev/null 2>&1; then
+      verbose "using existing mvn on PATH"
+      exec "$(command -v mvn)" "$@"
+    fi
+    ;;
+esac
 
 case "${distributionUrl-}" in
 *?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;


### PR DESCRIPTION
## Summary
- fall back to a Maven CLI already available on PATH when wrapper downloads are blocked

## Testing
- ./mvnw -v

------
https://chatgpt.com/codex/tasks/task_b_68f4994f8c4483338807643b46189536