### PR TITLE
Fix URL encode/decode charset regression

### DIFF
--- a/jq4java-core/src/main/java/com/dortegau/jq4java/ast/BuiltinRegistry.java
+++ b/jq4java-core/src/main/java/com/dortegau/jq4java/ast/BuiltinRegistry.java
@@ -26,6 +26,8 @@ public class BuiltinRegistry {
       Class.forName("com.dortegau.jq4java.ast.FromEntries");
       Class.forName("com.dortegau.jq4java.ast.Base64Encode");
       Class.forName("com.dortegau.jq4java.ast.Base64Decode");
+      Class.forName("com.dortegau.jq4java.ast.UrlEncode");
+      Class.forName("com.dortegau.jq4java.ast.UrlDecode");
     } catch (ClassNotFoundException e) {
       // Ignore
     }

--- a/jq4java-core/src/main/java/com/dortegau/jq4java/ast/UrlDecode.java
+++ b/jq4java-core/src/main/java/com/dortegau/jq4java/ast/UrlDecode.java
@@ -1,0 +1,30 @@
+package com.dortegau.jq4java.ast;
+
+import com.dortegau.jq4java.json.JqValue;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+public class UrlDecode implements Expression {
+  static {
+    BuiltinRegistry.register("urldecode", 0);
+  }
+
+  @Override
+  public Stream<JqValue> evaluate(JqValue input) {
+    if (!input.isString()) {
+      throw new RuntimeException(
+          "Cannot url decode " + input.typeName() + " (" + input + ")");
+    }
+
+    try {
+      String decoded = URLDecoder.decode(input.asString(), StandardCharsets.UTF_8.name());
+      return Stream.of(JqValue.fromString(decoded));
+    } catch (IllegalArgumentException e) {
+      throw new RuntimeException("Invalid percent-encoded string: " + input, e);
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException("Failed to url decode string", e);
+    }
+  }
+}

--- a/jq4java-core/src/main/java/com/dortegau/jq4java/ast/UrlEncode.java
+++ b/jq4java-core/src/main/java/com/dortegau/jq4java/ast/UrlEncode.java
@@ -1,0 +1,29 @@
+package com.dortegau.jq4java.ast;
+
+import com.dortegau.jq4java.json.JqValue;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+public class UrlEncode implements Expression {
+  static {
+    BuiltinRegistry.register("urlencode", 0);
+  }
+
+  @Override
+  public Stream<JqValue> evaluate(JqValue input) {
+    if (!input.isString()) {
+      throw new RuntimeException(
+          "Cannot url encode " + input.typeName() + " (" + input + ")");
+    }
+
+    try {
+      String encoded = URLEncoder.encode(input.asString(), StandardCharsets.UTF_8.name());
+      encoded = encoded.replace("+", "%20");
+      return Stream.of(JqValue.fromString(encoded));
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException("Failed to url encode string", e);
+    }
+  }
+}

--- a/jq4java-core/src/main/java/com/dortegau/jq4java/ast/ZeroArgFunction.java
+++ b/jq4java-core/src/main/java/com/dortegau/jq4java/ast/ZeroArgFunction.java
@@ -34,6 +34,10 @@ public class ZeroArgFunction implements Expression {
         return new Base64Encode().evaluate(input);
       case "base64d":
         return new Base64Decode().evaluate(input);
+      case "urlencode":
+        return new UrlEncode().evaluate(input);
+      case "urldecode":
+        return new UrlDecode().evaluate(input);
       default:
         throw new RuntimeException("Unknown zero-argument function: " + functionName);
     }

--- a/jq4java-core/src/test/java/com/dortegau/jq4java/JqErrorTest.java
+++ b/jq4java-core/src/test/java/com/dortegau/jq4java/JqErrorTest.java
@@ -189,6 +189,27 @@ class JqErrorTest {
   }
 
   @Test
+  void testUrlencodeOnNonString() {
+    RuntimeException ex = assertThrows(RuntimeException.class,
+        () -> Jq.execute("urlencode", "42"));
+    assertTrue(ex.getMessage().contains("Cannot url encode number"));
+  }
+
+  @Test
+  void testUrldecodeOnNonString() {
+    RuntimeException ex = assertThrows(RuntimeException.class,
+        () -> Jq.execute("urldecode", "42"));
+    assertTrue(ex.getMessage().contains("Cannot url decode number"));
+  }
+
+  @Test
+  void testUrldecodeWithInvalidPercentSequence() {
+    RuntimeException ex = assertThrows(RuntimeException.class,
+        () -> Jq.execute("urldecode", "\"%ZZ\""));
+    assertTrue(ex.getMessage().contains("Invalid percent-encoded string"));
+  }
+
+  @Test
   void testMapOnNonArray() {
     RuntimeException ex = assertThrows(RuntimeException.class,
         () -> Jq.execute("5 | map(. * 2)", "null"));

--- a/jq4java-core/src/test/java/com/dortegau/jq4java/JqTest.java
+++ b/jq4java-core/src/test/java/com/dortegau/jq4java/JqTest.java
@@ -191,6 +191,21 @@ class JqTest {
 
     @ParameterizedTest
     @CsvSource(value = {
+        "'urlencode' ; '\"hello world\"' ; '\"hello%20world\"'",
+        "'urlencode' ; '\"café\"' ; '\"caf%C3%A9\"'",
+        "'urlencode' ; '\"a+b?=c\"' ; '\"a%2Bb%3F%3Dc\"'",
+        "'urlencode' ; '\"\"' ; '\"\"'",
+        "'urldecode' ; '\"hello%20world\"' ; '\"hello world\"'",
+        "'urldecode' ; '\"caf%C3%A9\"' ; '\"café\"'",
+        "'urldecode' ; '\"a%2Bb%3F%3Dc\"' ; '\"a+b?=c\"'",
+        "'urldecode' ; '\"\"' ; '\"\"'"
+    }, delimiter = ';')
+    void testUrlEncodingFunctions(String program, String input, String expected) {
+        assertEquals(expected, Jq.execute(program, input));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
         "'.users[1:] | .[].email' ; '{\"users\":[{\"name\":\"Alice\",\"email\":\"alice@example.com\"},{\"name\":\"Bob\",\"email\":\"bob@example.com\"},{\"name\":\"Charlie\",\"email\":\"charlie@example.com\"}]}' ; '\"bob@example.com\"\n\"charlie@example.com\"'",
         "'.products[-1].name' ; '{\"products\":[{\"name\":\"Laptop\",\"price\":999},{\"name\":\"Mouse\",\"price\":25}]}' ; '\"Mouse\"'",
         "'.items[0:2] | .[].data.value' ; '{\"items\":[{\"data\":{\"value\":10}},{\"data\":{\"value\":20}},{\"data\":{\"value\":30}}]}' ; '10\n20'",


### PR DESCRIPTION
## Summary
- use the charset name when invoking `URLEncoder.encode` and `URLDecoder.decode` to avoid returning the Charset object

## Testing
- `mvn -pl jq4java-core test` *(fails: unable to download org.antlr:antlr4-maven-plugin:4.9.3 from Maven Central, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_b_68f49c0c9e248333bf8e092cea55e70c