### PR TITLE
Refactor with_entries to reuse existing builtins

### DIFF
--- a/jq4java-core/src/main/java/com/dortegau/jq4java/ast/BuiltinRegistry.java
+++ b/jq4java-core/src/main/java/com/dortegau/jq4java/ast/BuiltinRegistry.java
@@ -24,6 +24,7 @@ public class BuiltinRegistry {
       Class.forName("com.dortegau.jq4java.ast.Range");
       Class.forName("com.dortegau.jq4java.ast.ToEntries");
       Class.forName("com.dortegau.jq4java.ast.FromEntries");
+      Class.forName("com.dortegau.jq4java.ast.WithEntries");
       Class.forName("com.dortegau.jq4java.ast.Base64Encode");
       Class.forName("com.dortegau.jq4java.ast.Base64Decode");
       Class.forName("com.dortegau.jq4java.ast.UrlEncode");

--- a/jq4java-core/src/main/java/com/dortegau/jq4java/ast/WithEntries.java
+++ b/jq4java-core/src/main/java/com/dortegau/jq4java/ast/WithEntries.java
@@ -1,0 +1,22 @@
+package com.dortegau.jq4java.ast;
+
+import com.dortegau.jq4java.json.JqValue;
+import java.util.stream.Stream;
+
+public class WithEntries implements Expression {
+  static {
+    BuiltinRegistry.register("with_entries", 1);
+  }
+
+  private final Expression pipeline;
+
+  public WithEntries(Expression mapper) {
+    this.pipeline =
+        new Pipe(new ToEntries(), new Pipe(new MapFunction(mapper), new FromEntries()));
+  }
+
+  @Override
+  public Stream<JqValue> evaluate(JqValue input) {
+    return pipeline.evaluate(input);
+  }
+}

--- a/jq4java-core/src/main/java/com/dortegau/jq4java/parser/JqAstBuilder.java
+++ b/jq4java-core/src/main/java/com/dortegau/jq4java/parser/JqAstBuilder.java
@@ -29,6 +29,7 @@ import com.dortegau.jq4java.ast.ToEntries;
 import com.dortegau.jq4java.ast.Type;
 import com.dortegau.jq4java.ast.UnaryMinus;
 import com.dortegau.jq4java.ast.ZeroArgFunction;
+import com.dortegau.jq4java.ast.WithEntries;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -401,6 +402,11 @@ public class JqAstBuilder extends JqGrammarBaseVisitor<Expression> {
           throw new RuntimeException("map/" + arguments.size() + " is not defined");
         }
         return new MapFunction(arguments.get(0));
+      case "with_entries":
+        if (arguments.size() != 1) {
+          throw new RuntimeException("with_entries/" + arguments.size() + " is not defined");
+        }
+        return new WithEntries(arguments.get(0));
       case "select":
         if (arguments.size() != 1) {
           throw new RuntimeException("select/" + arguments.size() + " is not defined");

--- a/jq4java-core/src/test/java/com/dortegau/jq4java/JqErrorTest.java
+++ b/jq4java-core/src/test/java/com/dortegau/jq4java/JqErrorTest.java
@@ -553,6 +553,34 @@ class JqErrorTest {
   }
 
   @Test
+  void testWithEntriesOnString() {
+    RuntimeException ex = assertThrows(RuntimeException.class,
+        () -> Jq.execute("\"string\" | with_entries(.)", "null"));
+    assertTrue(ex.getMessage().contains("has no keys"));
+  }
+
+  @Test
+  void testWithEntriesOnNumber() {
+    RuntimeException ex = assertThrows(RuntimeException.class,
+        () -> Jq.execute("5 | with_entries(.)", "null"));
+    assertTrue(ex.getMessage().contains("has no keys"));
+  }
+
+  @Test
+  void testWithEntriesWithNonObjectResult() {
+    RuntimeException ex = assertThrows(RuntimeException.class,
+        () -> Jq.execute("{\"a\":1} | with_entries(.value)", "null"));
+    assertTrue(ex.getMessage().contains("Cannot index number with string"));
+  }
+
+  @Test
+  void testWithEntriesMissingKey() {
+    RuntimeException ex = assertThrows(RuntimeException.class,
+        () -> Jq.execute("{\"a\":1} | with_entries({value: .value})", "null"));
+    assertTrue(ex.getMessage().contains("Cannot use null (null) as object key"));
+  }
+
+  @Test
   void testUnaryMinusOnNull() {
     RuntimeException ex = assertThrows(RuntimeException.class,
         () -> Jq.execute("-.", "null"));

--- a/jq4java-core/src/test/java/com/dortegau/jq4java/JqTest.java
+++ b/jq4java-core/src/test/java/com/dortegau/jq4java/JqTest.java
@@ -681,6 +681,17 @@ class JqTest {
 
     @ParameterizedTest
     @CsvSource(value = {
+        "'with_entries({key: .key, value: (.value + 1)})' ; '{\"a\": 1, \"b\": 2}' ; '{\"a\":2,\"b\":3}'",
+        "'with_entries(select(.key == \"b\"))' ; '{\"a\": 1, \"b\": 2}' ; '{\"b\":2}'",
+        "'with_entries({key: (\"prefix_\" + .key), value: .value})' ; '{\"a\": 1}' ; '{\"prefix_a\":1}'",
+        "'with_entries(.)' ; '[1,2]' ; '{\"0\":1,\"1\":2}'"
+    }, delimiter = ';')
+    void testWithEntries(String program, String input, String expected) {
+        assertEquals(expected, Jq.execute(program, input));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
         // Basic unary minus with numbers (happy path)
         "'-.' ; '5' ; '-5'",
         "'-.' ; '-3' ; '3'",


### PR DESCRIPTION
## Summary
- rebuild the `with_entries` builtin as a pipe of `to_entries`, `map`, and `from_entries`
- delegate evaluation to the existing entry transformations instead of reimplementing them manually

## Testing
- ./mvnw -pl jq4java-core test *(fails: Unable to download org.antlr:antlr4-maven-plugin:4.9.3 due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_b_68f4ac7e7a3883338908c6389147b23f