### PR TITLE
Add GitHub Actions workflow to publish Javadoc

### DIFF
--- a/.github/workflows/javadoc-pages.yml
+++ b/.github/workflows/javadoc-pages.yml
@@ -1,0 +1,49 @@
+name: Deploy Javadoc
+
+on:
+  push:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Generate Javadoc
+        run: ./mvnw -B -DskipTests -Dmaven.javadoc.failOnError=false javadoc:aggregate
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: target/site/apidocs
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that generates the aggregated Javadoc with Maven
- publish the generated documentation to GitHub Pages using the recommended deploy actions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68f4ee9f15d08333b536e36915599278