### PR TITLE
Add tests verifying field access pipe equivalence

### DIFF
--- a/jq4java-core/src/test/java/com/dortegau/jq4java/JqTest.java
+++ b/jq4java-core/src/test/java/com/dortegau/jq4java/JqTest.java
@@ -67,6 +67,19 @@ class JqTest {
 
     @ParameterizedTest
     @CsvSource({
+        ".foo.bar, .foo | .bar, '{\"foo\": {\"bar\": 42}}'",
+        ".foo.bar, .foo | .bar, '{\"foo\": {\"bar\": {\"baz\": 1}}}'",
+        ".foo.bar, .foo | .bar, '{\"foo\": {\"bar\": [1,2,3]}}'"
+    })
+    void testFieldAccessPipeEquivalence(String composedFilter, String pipedFilter, String input) {
+        assertEquals(
+            Jq.execute(composedFilter, input),
+            Jq.execute(pipedFilter, input)
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
         ".[], '[1,2,3]', '1\n2\n3'",
         ".[] | .[], '[[1,2],[3,4]]', '1\n2\n3\n4'",
         ".[], '[]', ''",


### PR DESCRIPTION
## Summary
- add a parameterized test that compares the results of `.foo.bar` and `.foo | .bar`
- cover objects, nested objects, and arrays to ensure the filter equivalence holds

## Testing
- `./mvnw -pl jq4java-core test` *(fails: 403 retrieving org.antlr:antlr4-maven-plugin from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_b_68f52856f75c8333aa4dce2bbaf1d55b