### PR TITLE
Align Javadoc Pages workflow with GitHub Pages guidance

### DIFF
--- a/.github/workflows/javadoc-pages.yml
+++ b/.github/workflows/javadoc-pages.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: "pages"
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -38,6 +38,9 @@ jobs:
             rm -rf target/site/apidocs
             mv target/reports/apidocs target/site/
           fi
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
 
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- ensure the Javadoc deployment workflow follows the GitHub Pages static site template
- configure Pages before uploading the aggregated Javadoc artifact
- keep deployments running while newer runs queue for publication

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f529571a10833395702fe4e51ce7b7