### PR TITLE
Define constant for 'range' literal to eliminate duplication (#45)

### DIFF
--- a/jq4java-core/src/main/java/com/dortegau/jq4java/ast/Range.java
+++ b/jq4java-core/src/main/java/com/dortegau/jq4java/ast/Range.java
@@ -10,12 +10,13 @@ import java.util.stream.Stream;
  * AST node representing the range function for sequence generation.
  */
 public class Range implements Expression {
+  private static final String FUNCTION_NAME = "range";
   private final List<Expression> arguments;
 
   static {
-    BuiltinRegistry.register("range", 1);
-    BuiltinRegistry.register("range", 2);
-    BuiltinRegistry.register("range", 3);
+    BuiltinRegistry.register(FUNCTION_NAME, 1);
+    BuiltinRegistry.register(FUNCTION_NAME, 2);
+    BuiltinRegistry.register(FUNCTION_NAME, 3);
   }
 
   public Range(List<Expression> arguments) {
@@ -25,18 +26,18 @@ public class Range implements Expression {
   @Override
   public Stream<JqValue> evaluate(JqValue input) {
     if (arguments.size() < 1 || arguments.size() > 3) {
-      throw new RuntimeException("range/" + arguments.size() + " is not defined");
+      throw new RuntimeException(FUNCTION_NAME + "/" + arguments.size() + " is not defined");
     }
 
     List<JqValue> args = new ArrayList<>();
     for (Expression arg : arguments) {
       List<JqValue> values = arg.evaluate(input).collect(Collectors.toList());
       if (values.size() != 1) {
-        throw new RuntimeException("range arguments must produce exactly one value");
+        throw new RuntimeException(FUNCTION_NAME + " arguments must produce exactly one value");
       }
       JqValue value = values.get(0);
       if (!value.isNumber()) {
-        throw new RuntimeException("range argument must be a number");
+        throw new RuntimeException(FUNCTION_NAME + " argument must be a number");
       }
       args.add(value);
     }
@@ -76,7 +77,7 @@ public class Range implements Expression {
       double step = args.get(2).asNumber();
 
       if (step == 0) {
-        throw new RuntimeException("range step cannot be zero");
+        throw new RuntimeException(FUNCTION_NAME + " step cannot be zero");
       }
 
       if (step > 0) {


### PR DESCRIPTION
## Summary
- Define a constant `FUNCTION_NAME = "range"` to eliminate string literal duplication
- Replace all hardcoded "range" strings with the constant throughout Range.java
- Improve code maintainability and reduce potential for typos

## Details
This refactoring addresses the code quality issue identified in GitHub issue #45 where the string literal "range" was duplicated 3 times in the Range.java file.

### Changes Made:
- Added `private static final String FUNCTION_NAME = "range";` constant
- Updated `BuiltinRegistry.register()` calls to use the constant (lines 17-19)
- Updated error messages to use the constant for consistency:
  - Invalid arity error message (line 29)
  - Multiple values error message (line 36) 
  - Non-number argument error message (line 40)
  - Zero step error message (line 80)

## Test Plan
- [x] All existing tests pass (476 tests, 0 failures)
- [x] Range function behavior unchanged - comprehensive test coverage exists
- [x] Error messages still contain "range" string as expected
- [x] No functional changes - pure refactoring for code quality

The existing test suite provides excellent coverage for the range function including:
- Single argument: `range(5)` → `[0,1,2,3,4]`
- Two arguments: `range(2;7)` → `[2,3,4,5,6]` 
- Three arguments with step: `range(0;10;3)` → `[0,3,6,9]`
- Error cases: zero step, non-numeric arguments, invalid arity

## Architecture Compliance
✅ No external dependencies added
✅ Follows existing code patterns
✅ Maintains error message consistency
✅ No functional behavior changes

Closes #45